### PR TITLE
add relative path (URL) support

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -1,6 +1,7 @@
 var webpack = require('webpack')
 
 module.exports = {
+  publicPath: process.env.VUE_APP_URL ? process.env.VUE_APP_URL : '.',
   configureWebpack: {
     resolve: {
       alias: {


### PR DESCRIPTION
Currently it is not possible to start plantuml-editor with a relative URL like `https://sub.exmaple.com/plantuml-editor` instead of `https://sub.exmaple.com`.

The reason for this is that the `publicPath` in the `vue.config.js` was not explicitly set. This pulls the default value `/`, which always loads everything from the root directory of the servers.